### PR TITLE
feat: redesign layout with sidebar and statusline

### DIFF
--- a/src/components/footer.rs
+++ b/src/components/footer.rs
@@ -1,35 +1,48 @@
 use ratatui::{
     Frame,
-    layout::Alignment,
+    layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Style, Stylize},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Paragraph},
+    widgets::Paragraph,
 };
 
 pub struct Footer;
 
 impl Footer {
     pub fn render(f: &mut Frame, area: ratatui::prelude::Rect) {
-        let footer_block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Rgb(80, 80, 80)))
-            .style(Style::default().bg(Color::Rgb(25, 25, 35)));
+        // Create horizontal split for statusline
+        let statusline_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Min(0),        // Left side - commands
+                Constraint::Length(20),    // Right side - status info
+            ])
+            .split(area);
 
-        let footer_content = Paragraph::new(vec![Line::from(vec![
-            Span::raw("  "),
-            Span::styled("Press ", Style::default().fg(Color::Rgb(150, 150, 150))),
+        // Left side - key commands
+        let commands_content = Paragraph::new(Line::from(vec![
             Span::styled("q", Style::default().fg(Color::Red).bold()),
-            Span::styled(" or ", Style::default().fg(Color::Rgb(150, 150, 150))),
+            Span::raw("/"),
             Span::styled("ESC", Style::default().fg(Color::Red).bold()),
-            Span::styled(" to quit", Style::default().fg(Color::Rgb(150, 150, 150))),
-            Span::raw("  •  "),
+            Span::raw(" quit  "),
             Span::styled("?", Style::default().fg(Color::Magenta).bold()),
-            Span::styled(" for help", Style::default().fg(Color::Rgb(150, 150, 150))),
-        ])])
-        .block(footer_block)
+            Span::raw(" help  "),
+            Span::styled("p", Style::default().fg(Color::Yellow).bold()),
+            Span::raw(" add project  "),
+            Span::styled("n", Style::default().fg(Color::Green).bold()),
+            Span::raw(" new session"),
+        ]))
+        .style(Style::default().bg(Color::Rgb(20, 20, 30)).fg(Color::Rgb(200, 200, 200)))
         .alignment(Alignment::Left);
 
-        f.render_widget(footer_content, area);
+        // Right side - status info
+        let status_content = Paragraph::new(Line::from(vec![
+            Span::styled("Ready", Style::default().fg(Color::Green).bold()),
+        ]))
+        .style(Style::default().bg(Color::Rgb(20, 20, 30)).fg(Color::Rgb(200, 200, 200)))
+        .alignment(Alignment::Right);
+
+        f.render_widget(commands_content, statusline_chunks[0]);
+        f.render_widget(status_content, statusline_chunks[1]);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,7 @@ use ratatui::{
 
 use crate::app::{App, AppMode};
 use crate::components::{
-    Footer, Header, SessionsPanel, ProjectsPanel, StatsPanel,
+    Footer, Header, SessionsPanel,
     HelpModal, FilePickerModal, ConfirmationModal,
 };
 use crate::components::modals::ProjectInitModal;
@@ -83,17 +83,16 @@ fn ui(f: &mut Frame, app: &App) {
 }
 
 fn render_main_content(f: &mut Frame, area: ratatui::prelude::Rect, app: &App) {
-    // New 3-panel layout: Sessions (30%) | Projects (45%) | Stats (25%)
+    // New 2-panel layout: Sessions sidebar (25%) | Empty main area (75%)
     let content_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Percentage(30), // Sessions
-            Constraint::Percentage(45), // Projects
-            Constraint::Percentage(25), // Stats
+            Constraint::Percentage(25), // Sessions sidebar
+            Constraint::Percentage(75), // Empty main content area
         ])
         .split(area);
 
-    // Render the three main panels
+    // Render sessions sidebar
     SessionsPanel::render(
         f,
         content_chunks[0],
@@ -101,19 +100,41 @@ fn render_main_content(f: &mut Frame, area: ratatui::prelude::Rect, app: &App) {
         app.selected_session_index
     );
 
-    ProjectsPanel::render(
-        f,
-        content_chunks[1],
-        &app.data.projects,
-        app.selected_project_index
-    );
+    // Render empty main content area
+    render_empty_content(f, content_chunks[1]);
+}
 
-    StatsPanel::render(
-        f,
-        content_chunks[2],
-        &app.data.stats,
-        &app.data.sessions
-    );
+fn render_empty_content(f: &mut Frame, area: ratatui::prelude::Rect) {
+    use ratatui::{
+        text::{Line, Span, Text},
+        widgets::{Block, BorderType, Borders, Paragraph},
+        style::{Color, Style, Stylize},
+        layout::Alignment,
+    };
+
+    let empty_block = Block::default()
+        .title("📝 Main Content")
+        .title_style(Style::default().fg(Color::Rgb(100, 150, 200)).bold())
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::Rgb(60, 60, 80)))
+        .style(Style::default().bg(Color::Rgb(15, 15, 25)));
+
+    let empty_content = Paragraph::new(Text::from(vec![
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Content area", Style::default().fg(Color::Rgb(150, 150, 150)).italic()),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("This space is reserved for future content.", Style::default().fg(Color::Rgb(120, 120, 120))),
+        ]),
+    ]))
+    .block(empty_block)
+    .alignment(Alignment::Center);
+
+    f.render_widget(empty_content, area);
 }
 
 pub fn run() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
## Summary
- Transform footer into a clean statusline showing key commands and status
- Restructure main layout to sidebar (sessions) + empty content area  
- Replace 3-panel layout with 2-panel: 25% sessions sidebar, 75% main content
- Add placeholder content area ready for future development

## Changes Made
- **Footer → Statusline**: Converted bordered footer to flat statusline with commands on left, status on right
- **Layout restructure**: Changed from Sessions|Projects|Stats to Sessions|Empty Content
- **Sessions sidebar**: Existing sessions panel now serves as left sidebar (25% width)
- **Empty content area**: Clean placeholder ready for future content (75% width)
- **Code cleanup**: Removed unused component imports

## Test plan
- [x] Build compiles successfully
- [x] Layout renders correctly with new sidebar structure
- [x] Statusline displays key commands and status
- [x] Sessions sidebar shows active/stopped sessions properly
- [x] Empty content area displays placeholder text

🤖 Generated with [Claude Code](https://claude.ai/code)